### PR TITLE
Development: Fix generated client consumers

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3076,7 +3076,7 @@ components:
         feedback: {type: string, description: Suggested feedback, minLength: 1}
         usageCount: {type: integer, format: int32, description: Maximum number of
             uses, minimum: 0}
-      required: [feedback, gradingScale, instructionDescription]
+      required: [credits, feedback, gradingScale, instructionDescription, usageCount]
     TutorialGroupFreePeriod:
       type: object
       properties:
@@ -3833,7 +3833,7 @@ components:
           items: {$ref: '#/components/schemas/GeneratedAssessmentInstruction'}
           maxItems: 3
           minItems: 3
-      required: [title]
+      required: [bonus, structuredGradingInstructions, title]
     QuizExerciseReEvaluate:
       type: object
       properties:

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/dto/GeneratedAssessmentCriterionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/dto/GeneratedAssessmentCriterionDTO.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -16,6 +17,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @Schema(description = "Generated structured assessment criterion")
 public record GeneratedAssessmentCriterionDTO(@NotBlank @Size(max = 255) @Schema(description = "Criterion title") String title,
-        @Schema(description = "Whether the criterion awards bonus points") boolean bonus,
-        @Size(min = 3, max = 3) @Schema(description = "Full-credit, partial-credit, and no-credit instructions, in that order") List<@Valid GeneratedAssessmentInstructionDTO> structuredGradingInstructions) {
+        @Schema(description = "Whether the criterion awards bonus points", requiredMode = Schema.RequiredMode.REQUIRED) boolean bonus,
+        @NotNull @Size(min = 3, max = 3) @Schema(description = "Full-credit, partial-credit, and no-credit instructions, in that order") List<@Valid GeneratedAssessmentInstructionDTO> structuredGradingInstructions) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/dto/GeneratedAssessmentInstructionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/dto/GeneratedAssessmentInstructionDTO.java
@@ -14,8 +14,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @Schema(description = "Generated structured grading instruction")
-public record GeneratedAssessmentInstructionDTO(@DecimalMin("0") @Schema(description = "Nonnegative credits awarded") double credits,
+public record GeneratedAssessmentInstructionDTO(@DecimalMin("0") @Schema(description = "Nonnegative credits awarded", requiredMode = Schema.RequiredMode.REQUIRED) double credits,
         @NotBlank @Size(max = 255) @Schema(description = "Grading scale label") String gradingScale,
         @NotBlank @Schema(description = "Assessment instruction") String instructionDescription, @NotBlank @Schema(description = "Suggested feedback") String feedback,
-        @Min(0) @Schema(description = "Maximum number of uses") int usageCount) {
+        @Min(0) @Schema(description = "Maximum number of uses", requiredMode = Schema.RequiredMode.REQUIRED) int usageCount) {
 }

--- a/src/main/webapp/app/course/overview/course-overview/course-overview.component.spec.ts
+++ b/src/main/webapp/app/course/overview/course-overview/course-overview.component.spec.ts
@@ -18,6 +18,7 @@ import { TeamAssignmentPayload } from 'app/exercise/shared/entities/team/team.mo
 import { Exam } from 'app/exam/shared/entities/exam.model';
 import { BarControlConfiguration, BarControlConfigurationProvider } from 'app/shared-ui/tab-bar/tab-bar';
 import { TutorialGroup } from 'app/tutorialgroup/shared/entities/tutorial-group.model';
+import { TutorialGroupSummary } from 'app/openapi/model/tutorial-group-summary';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { NgbDropdown, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
@@ -681,8 +682,8 @@ describe('CourseOverviewComponent', () => {
     it('should have competencies and tutorial groups', () => {
         const getCourseStub = vi.spyOn(courseStorageService, 'getCourse');
 
-        const tutorialGroupsResponse: HttpResponse<TutorialGroup[]> = new HttpResponse({
-            body: [new TutorialGroup()],
+        const tutorialGroupsResponse: HttpResponse<TutorialGroupSummary[]> = new HttpResponse({
+            body: [{}],
             status: 200,
         });
         const configurationResponse: HttpResponse<TutorialGroupConfigurationDTO> = new HttpResponse({

--- a/src/main/webapp/app/openapi/model/generated-assessment-criterion.ts
+++ b/src/main/webapp/app/openapi/model/generated-assessment-criterion.ts
@@ -17,7 +17,7 @@ export interface GeneratedAssessmentCriterion {
     /** Criterion title */
     title: string;
     /** Whether the criterion awards bonus points */
-    bonus?: boolean;
+    bonus: boolean;
     /** Full-credit, partial-credit, and no-credit instructions, in that order */
-    structuredGradingInstructions?: Array<GeneratedAssessmentInstruction>;
+    structuredGradingInstructions: Array<GeneratedAssessmentInstruction>;
 }

--- a/src/main/webapp/app/openapi/model/generated-assessment-instruction.ts
+++ b/src/main/webapp/app/openapi/model/generated-assessment-instruction.ts
@@ -14,7 +14,7 @@
  */
 export interface GeneratedAssessmentInstruction {
     /** Nonnegative credits awarded */
-    credits?: number;
+    credits: number;
     /** Grading scale label */
     gradingScale: string;
     /** Assessment instruction */
@@ -22,5 +22,5 @@ export interface GeneratedAssessmentInstruction {
     /** Suggested feedback */
     feedback: string;
     /** Maximum number of uses */
-    usageCount?: number;
+    usageCount: number;
 }

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.ts
@@ -27,7 +27,7 @@ import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pip
 import { MeetingPatternPipe } from 'app/tutorialgroup/shared/pipe/meeting-pattern.pipe';
 import { CourseTitleBarActionsDirective } from 'app/course/shared/directives/course-title-bar-actions.directive';
 import { TutorialGroupApi } from 'app/openapi/api/tutorial-group-api';
-import { convertTutorialGroupArrayDatesFromServer } from 'app/tutorialgroup/shared/util/convertTutorialGroupEntityDates';
+import { convertTutorialGroupSummaryArrayDatesFromServer } from 'app/tutorialgroup/shared/util/convertTutorialGroupEntityDates';
 import { tutorialGroupUtilization } from 'app/tutorialgroup/shared/util/tutorial-group-utilization';
 import { TutorialGroupsImportButtonComponent } from './tutorial-groups-import-button/tutorial-groups-import-button.component';
 import { TutorialGroupsExportButtonComponent } from './tutorial-groups-export-button.component/tutorial-groups-export-button.component';
@@ -242,7 +242,7 @@ export class TutorialGroupsManagementComponent {
         this.tutorialGroupApiService
             .getTutorialGroupsForCourse(courseId)
             .pipe(
-                map((tutorialGroups: TutorialGroup[]) => convertTutorialGroupArrayDatesFromServer(tutorialGroups)),
+                map(convertTutorialGroupSummaryArrayDatesFromServer),
                 finalize(() => this.isLoading.set(false)),
                 takeUntilDestroyed(this.destroyRef),
             )

--- a/src/main/webapp/app/tutorialgroup/overview/course-tutorial-groups/course-tutorial-groups.component.ts
+++ b/src/main/webapp/app/tutorialgroup/overview/course-tutorial-groups/course-tutorial-groups.component.ts
@@ -21,7 +21,7 @@ import { Lecture } from 'app/lecture/shared/entities/lecture.model';
 import { LectureService } from 'app/lecture/manage/services/lecture.service';
 import dayjs from 'dayjs/esm';
 import { TutorialGroupApi } from 'app/openapi/api/tutorial-group-api';
-import { convertTutorialGroupArrayDatesFromServer } from 'app/tutorialgroup/shared/util/convertTutorialGroupEntityDates';
+import { convertTutorialGroupSummaryArrayDatesFromServer } from 'app/tutorialgroup/shared/util/convertTutorialGroupEntityDates';
 import { SidebarView } from 'app/course/shared/sidebar-view.interface';
 
 @Component({
@@ -145,7 +145,7 @@ export class CourseTutorialGroupsComponent implements SidebarView {
     private loadAndSetTutorialGroups(courseId: number) {
         this.tutorialGroupApiService
             .getTutorialGroupsForCourse(courseId)
-            .pipe(map((tutorialGroups: TutorialGroup[]) => convertTutorialGroupArrayDatesFromServer(tutorialGroups)))
+            .pipe(map(convertTutorialGroupSummaryArrayDatesFromServer))
             .subscribe({
                 next: (tutorialGroups) => {
                     this.tutorialGroups.set(tutorialGroups);

--- a/src/main/webapp/app/tutorialgroup/shared/util/convertTutorialGroupEntityDates.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/shared/util/convertTutorialGroupEntityDates.spec.ts
@@ -6,6 +6,7 @@ import {
     convertTutorialGroupDatesFromServer,
     convertTutorialGroupFreePeriodDatesFromServer,
     convertTutorialGroupSessionDatesFromServer,
+    convertTutorialGroupSummaryArrayDatesFromServer,
     convertTutorialGroupsConfigurationDatesFromServer,
 } from 'app/tutorialgroup/shared/util/convertTutorialGroupEntityDates';
 import { TutorialGroup } from 'app/tutorialgroup/shared/entities/tutorial-group.model';
@@ -14,6 +15,7 @@ import { TutorialGroupSchedule } from 'app/tutorialgroup/shared/entities/tutoria
 import { LegacyTutorialGroupSession } from 'app/tutorialgroup/shared/entities/tutorial-group-session.model';
 import { TutorialGroupsConfiguration } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration.model';
 import { Dayjs } from 'dayjs/esm';
+import { TutorialGroupSummary } from 'app/openapi/model/tutorial-group-summary';
 
 const START = '2026-03-26T10:00:00.000Z';
 const END = '2026-03-26T12:00:00.000Z';
@@ -137,5 +139,51 @@ describe('convertTutorialGroupEntityDates', () => {
 
         expect(dayjs.isDayjs(result[0].nextSession?.start)).toBe(true);
         expect(dayjs.isDayjs(result[0].nextSession?.end)).toBe(true);
+    });
+
+    it('should convert generated tutorial group summaries to entity date types', () => {
+        const tutorialGroup: TutorialGroupSummary = {
+            tutorialGroupSchedule: {
+                validFromInclusive: VALID_FROM,
+                validToInclusive: VALID_TO,
+            },
+            tutorialGroupSessions: [
+                {
+                    start: START,
+                    end: END,
+                    tutorialGroupFreePeriod: {
+                        start: NEXT_START,
+                        end: NEXT_END,
+                    },
+                },
+            ],
+            nextSession: {
+                start: NEXT_START,
+                end: NEXT_END,
+            },
+            channel: {
+                creationDate: START,
+                lastMessageDate: END,
+                lastReadDate: NEXT_START,
+                subTypeReferenceStartDate: VALID_FROM,
+                subTypeReferenceEndDate: VALID_TO,
+            },
+        };
+
+        const [result] = convertTutorialGroupSummaryArrayDatesFromServer([tutorialGroup]);
+
+        expect(dayjs.isDayjs(result.tutorialGroupSchedule?.validFromInclusive)).toBe(true);
+        expect(dayjs.isDayjs(result.tutorialGroupSchedule?.validToInclusive)).toBe(true);
+        expect(dayjs.isDayjs(result.tutorialGroupSessions?.[0].start)).toBe(true);
+        expect(dayjs.isDayjs(result.tutorialGroupSessions?.[0].end)).toBe(true);
+        expect(dayjs.isDayjs(result.tutorialGroupSessions?.[0].tutorialGroupFreePeriod?.start)).toBe(true);
+        expect(dayjs.isDayjs(result.tutorialGroupSessions?.[0].tutorialGroupFreePeriod?.end)).toBe(true);
+        expect(dayjs.isDayjs(result.nextSession?.start)).toBe(true);
+        expect(dayjs.isDayjs(result.nextSession?.end)).toBe(true);
+        expect(dayjs.isDayjs(result.channel?.creationDate)).toBe(true);
+        expect(dayjs.isDayjs(result.channel?.lastMessageDate)).toBe(true);
+        expect(dayjs.isDayjs(result.channel?.lastReadDate)).toBe(true);
+        expect(dayjs.isDayjs(result.channel?.subTypeReferenceStartDate)).toBe(true);
+        expect(dayjs.isDayjs(result.channel?.subTypeReferenceEndDate)).toBe(true);
     });
 });

--- a/src/main/webapp/app/tutorialgroup/shared/util/convertTutorialGroupEntityDates.ts
+++ b/src/main/webapp/app/tutorialgroup/shared/util/convertTutorialGroupEntityDates.ts
@@ -1,8 +1,14 @@
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
+import { hydrate } from 'app/foundation/util/deep-clone.util';
+import { ChannelDTO } from 'app/communication/shared/entities/conversation/channel.model';
+import { TutorialGroupSummary } from 'app/openapi/model/tutorial-group-summary';
+import { TutorialGroupSummarySession } from 'app/openapi/model/tutorial-group-summary-session';
 import { TutorialGroupFreePeriod } from 'app/tutorialgroup/shared/entities/tutorial-group-free-day.model';
 import { TutorialGroup } from 'app/tutorialgroup/shared/entities/tutorial-group.model';
 import { LegacyTutorialGroupSession } from 'app/tutorialgroup/shared/entities/tutorial-group-session.model';
+import { TutorialGroupSchedule } from 'app/tutorialgroup/shared/entities/tutorial-group-schedule.model';
 import { TutorialGroupsConfiguration } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration.model';
+import dayjs from 'dayjs/esm';
 
 export function convertTutorialGroupFreePeriodDatesFromServer(tutorialGroupFreePeriod: TutorialGroupFreePeriod): TutorialGroupFreePeriod {
     tutorialGroupFreePeriod.start = convertDateFromServer(tutorialGroupFreePeriod.start);
@@ -55,4 +61,54 @@ export function convertTutorialGroupArrayDatesFromServer(tutorialGroups: Tutoria
         });
     }
     return tutorialGroups;
+}
+
+function convertGeneratedDateFromServer(date?: string): dayjs.Dayjs | undefined {
+    return date ? dayjs(date) : undefined;
+}
+
+function convertTutorialGroupSummarySessionDatesFromServer(tutorialGroupSession: TutorialGroupSummarySession): LegacyTutorialGroupSession {
+    const convertedSession = new LegacyTutorialGroupSession();
+    hydrate(convertedSession, tutorialGroupSession);
+    convertedSession.start = convertGeneratedDateFromServer(tutorialGroupSession.start);
+    convertedSession.end = convertGeneratedDateFromServer(tutorialGroupSession.end);
+    if (tutorialGroupSession.tutorialGroupFreePeriod) {
+        const convertedFreePeriod = new TutorialGroupFreePeriod();
+        hydrate(convertedFreePeriod, tutorialGroupSession.tutorialGroupFreePeriod);
+        convertedFreePeriod.start = convertGeneratedDateFromServer(tutorialGroupSession.tutorialGroupFreePeriod.start);
+        convertedFreePeriod.end = convertGeneratedDateFromServer(tutorialGroupSession.tutorialGroupFreePeriod.end);
+        convertedSession.tutorialGroupFreePeriod = convertedFreePeriod;
+    }
+    return convertedSession;
+}
+
+export function convertTutorialGroupSummaryArrayDatesFromServer(tutorialGroups: TutorialGroupSummary[]): TutorialGroup[] {
+    return tutorialGroups.map((tutorialGroup) => {
+        const { tutorialGroupSchedule, tutorialGroupSessions, nextSession, channel, ...properties } = tutorialGroup;
+        const convertedTutorialGroup = new TutorialGroup();
+        hydrate(convertedTutorialGroup, properties);
+
+        if (tutorialGroupSchedule) {
+            const convertedSchedule = new TutorialGroupSchedule();
+            hydrate(convertedSchedule, tutorialGroupSchedule);
+            convertedSchedule.validFromInclusive = convertGeneratedDateFromServer(tutorialGroupSchedule.validFromInclusive);
+            convertedSchedule.validToInclusive = convertGeneratedDateFromServer(tutorialGroupSchedule.validToInclusive);
+            convertedTutorialGroup.tutorialGroupSchedule = convertedSchedule;
+        }
+        convertedTutorialGroup.tutorialGroupSessions = tutorialGroupSessions?.map(convertTutorialGroupSummarySessionDatesFromServer);
+        convertedTutorialGroup.nextSession = nextSession ? convertTutorialGroupSummarySessionDatesFromServer(nextSession) : undefined;
+
+        if (channel) {
+            const convertedChannel = new ChannelDTO();
+            hydrate(convertedChannel, channel);
+            convertedChannel.creationDate = convertGeneratedDateFromServer(channel.creationDate);
+            convertedChannel.lastMessageDate = convertGeneratedDateFromServer(channel.lastMessageDate);
+            convertedChannel.lastReadDate = convertGeneratedDateFromServer(channel.lastReadDate);
+            convertedChannel.subTypeReferenceStartDate = convertGeneratedDateFromServer(channel.subTypeReferenceStartDate);
+            convertedChannel.subTypeReferenceEndDate = convertGeneratedDateFromServer(channel.subTypeReferenceEndDate);
+            convertedTutorialGroup.channel = convertedChannel;
+        }
+
+        return convertedTutorialGroup;
+    });
 }


### PR DESCRIPTION
### Summary
Updates existing client consumers for generated tutorial-group summary DTOs and makes Hyperion assessment response requirements explicit in OpenAPI.

### Motivation and Context
Final generated-client compilation exposed stale consumer types and optional primitive response fields outside the quiz module.

### Description
- Maps generated tutorial-group summaries into client entities with Dayjs date values.
- Updates tutorial-group consumers and their mocks to use the generated summary contract.
- Marks generated assessment instruction fields as required at the Java DTO boundary.
- Regenerates the affected OpenAPI models.

### Steps for Testing
1. Run the tutorial-group date conversion Vitest.
2. Run pnpm run compile:tests.
3. Run pnpm run webapp:prod.
4. Run ./gradlew test -DincludeTags=ArchitectureTest -x webapp.
5. Run the complete quiz test package.